### PR TITLE
performance fix for slow laggy scrolling.

### DIFF
--- a/CalendarIOS7/CalendarIOS7/CalendarIOS7/CALAgendaViewController.m
+++ b/CalendarIOS7/CalendarIOS7/CalendarIOS7/CALAgendaViewController.m
@@ -44,6 +44,7 @@
 @property (strong, nonatomic) CALAgendaMonthCollectionViewLayout *collectionMonthLayout;
 //Quarts selection
 @property (strong, nonatomic) CALDay *dayStructured;
+@property (strong, nonatomic) NSDateFormatter *sectionFormater;
 
 @end
 
@@ -71,6 +72,8 @@
         self.calendarCollectionView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     }
     
+    self.sectionFormater = [NSDateFormatter dateFormatterForType:CALDateFormatterType_dd_MM_yyyy];
+
     self.calendarCollectionView.delegate = self;
     [self.view addSubview:self.calendarCollectionView];
     self.calendarCollectionView.dataSource = self;
@@ -107,13 +110,12 @@
     self.eventsGroupByDay = [NSMutableDictionary new];
     for (id <CALgendaEvent> obj in self.events) {
         NSDate *startDate = [obj eventStartDate];
-        NSDateFormatter *sectionFormater = [NSDateFormatter dateFormatterForType:CALDateFormatterType_dd_MM_yyyy];
-        NSMutableArray *events = [self.eventsGroupByDay objectForKey:[sectionFormater stringFromDate:startDate]];
+        NSMutableArray *events = [self.eventsGroupByDay objectForKey:[self.sectionFormater stringFromDate:startDate]];
         if (events == nil) {
             events = [NSMutableArray new];
         }
         [events addObject:obj];
-        [self.eventsGroupByDay setObject:events forKey:[sectionFormater stringFromDate:startDate]];
+        [self.eventsGroupByDay setObject:events forKey:[self.sectionFormater stringFromDate:startDate]];
     }
 }
 
@@ -297,8 +299,7 @@
 - (NSArray *)eventsAtIndexPath:(NSIndexPath *)indexPath
 {
     NSDate *date = [self dateAtIndexPath:indexPath] ;
-    NSDateFormatter *sectionFormater = [NSDateFormatter dateFormatterForType:CALDateFormatterType_dd_MM_yyyy];
-    NSArray *events = [self.eventsGroupByDay objectForKey:[sectionFormater stringFromDate:date]];
+    NSArray *events = [self.eventsGroupByDay objectForKey:[self.sectionFormater stringFromDate:date]];
     return events;
 }
 


### PR DESCRIPTION
NSDateFormatter has a big overhead for instantiating.   If you run in the profiler, you will see that it's using a huge amount of time.

If you make sectionFormater a property of CALAgendaViewController, initialize it in viewDidLoad and reference it from -updateEventGroupByDays and -eventsAtIndexPath: you will see smooth scrolling, even on 4S iPhone.
